### PR TITLE
Fix rails 5 deprecated method error

### DIFF
--- a/lib/devise_google_authenticatable/rails.rb
+++ b/lib/devise_google_authenticatable/rails.rb
@@ -1,8 +1,13 @@
 module DeviseGoogleAuthenticator
   class Engine < ::Rails::Engine # :nodoc:
-    ActionDispatch::Callbacks.to_prepare do
-      DeviseGoogleAuthenticator::Patches.apply
+    if Rails.version > '5'
+      ActiveSupport::Reloader.to_prepare do
+        DeviseGoogleAuthenticator::Patches.apply
+      end
+    else
+      ActionDispatch::Callbacks.to_prepare do
+        DeviseGoogleAuthenticator::Patches.apply
+      end
     end
-
   end
 end


### PR DESCRIPTION
'ActionDispatch::Callbacks' is deprecated in rails5 so replace it with 'ActiveSupport::Reloader'