### PR TITLE
Fixes tests for latest Rails 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in gemtest.gemspec
 gemspec
 
+ruby_version = Gem::Version.new(ENV.fetch('EARTHLY_RUBY_VERSION'))
 rails_min_version = ENV.fetch('EARTHLY_RAILS_VERSION')
 rails_max_version = (rails_min_version.split('.').first.to_i + 1).to_s
 
@@ -18,7 +19,12 @@ gem 'capybara-screenshot'
 gem 'database_cleaner-active_record'
 gem 'factory_girl_rails'
 gem 'mocha', '~> 0.13.0'
-gem 'nokogiri', '~> 1.12.0' # Version 1.12.0 fixes error "uninitialized constant Nokogiri::HTML4"
+# With Ruby >= 3.0
+if ruby_version >= Gem::Version.new('3.0.0')
+  gem 'nokogiri', '~> 1.13.0'
+else
+  gem 'nokogiri', '~> 1.12.0'
+end
 gem 'responders'
 gem 'rubocop'
 gem 'shoulda'
@@ -29,4 +35,13 @@ else
 end
 gem 'test-unit'
 gem 'timecop'
+
+# With Ruby >= 3.0
+if ruby_version >= Gem::Version.new('3.0.0')
+  gem 'base64'
+  gem 'bigdecimal'
+  gem 'drb'
+  gem 'mutex_m'
+end
+
 # gem 'debugger'

--- a/docker-compose-earthly.yml
+++ b/docker-compose-earthly.yml
@@ -1,5 +1,7 @@
 version: '3'
 
+name: devise_gauth
+
 services:
   gem:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 version: '3'
 
+name: devise_gauth
+
 services:
   gem:
     build: .

--- a/test/rails_app/config/application.rb
+++ b/test/rails_app/config/application.rb
@@ -2,6 +2,7 @@
 
 require File.expand_path('../boot', __FILE__)
 
+require 'logger'
 require 'action_controller/railtie'
 require 'action_mailer/railtie'
 require 'rails/test_unit/railtie'

--- a/test/rails_app/script/rails
+++ b/test/rails_app/script/rails
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
 
+require 'logger'
 APP_PATH = File.expand_path('../../config/application',  __FILE__)
 require File.expand_path('../../config/boot',  __FILE__)
 require 'rails/commands'


### PR DESCRIPTION
The test suite is broken with the latest Rails 6.1 series:

```
==> Devise.orm = :active_record
/usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:16:in `<module:LoggerThreadSafeLevel>': uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)

    Logger::Severity.constants.each do |severity|
    ^^^^^^
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:9:in `<module:ActiveSupport>'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:8:in `<top (required)>'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_silence.rb:5:in `require'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger_silence.rb:5:in `<top (required)>'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger.rb:3:in `require'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/logger.rb:3:in `<top (required)>'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support.rb:29:in `require'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support.rb:29:in `<top (required)>'
	from /usr/local/bundle/gems/railties-6.1.7.10/lib/rails.rb:7:in `require'
	from /usr/local/bundle/gems/railties-6.1.7.10/lib/rails.rb:7:in `<top (required)>'
	from /usr/local/bundle/gems/actionpack-6.1.7.10/lib/action_controller/railtie.rb:3:in `require'
	from /usr/local/bundle/gems/actionpack-6.1.7.10/lib/action_controller/railtie.rb:3:in `<top (required)>'
        ...
```

This PR fixes it.